### PR TITLE
Replace PRIVATE_KEY_BASE64 with PRIVATE_KEY

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,6 +3,6 @@
     "NODE_ENV": "production",
     "APP_ID": "@app-id",
     "WEBHOOK_SECRET": "@webhook-secret",
-    "PRIVATE_KEY_BASE64": "@private-key-base64"
+    "PRIVATE_KEY": "@private-key-base64"
   }
 }


### PR DESCRIPTION
With `PRIVATE_KEY` automatically decoding base64 keys, `PRIVATE_KEY_BASE64` is no longer needed to distinguish how the key is formatted.